### PR TITLE
fixes #4

### DIFF
--- a/build.sh
+++ b/build.sh
@@ -1,4 +1,4 @@
 mkdir build
 cd build
-gcc `php-config --includes` -fpic -c ../wiringpi_wrap.c ../WiringPi/wiringPi/wiringPi.c ../WiringPi/wiringPi/wiringShift.c ../WiringPi/wiringPi/wiringSerial.c
-gcc -shared wiringpi_wrap.o wiringPi.o wiringSerial.o wiringShift.o -o wiringpi.so
+gcc `php-config --includes` -fpic -c ../wiringpi_wrap.c ../WiringPi/wiringPi/wiringPi.c ../WiringPi/wiringPi/wiringShift.c ../WiringPi/wiringPi/wiringSerial.c ../WiringPi/wiringPi/piHiPri.c
+gcc -shared wiringpi_wrap.o wiringPi.o wiringSerial.o piHiPri.o wiringShift.o -o wiringpi.so


### PR DESCRIPTION
needs the piHiPri library during build. This patches the build script to include the library. This fixes the bug in issue #4.
